### PR TITLE
Automatic configuration of `PS_WORDSIZE`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ config:
 	@rm -f $(PLATFILE)
 	@echo '#ifndef PS_PLAT_H'                          >  $(PLATFILE)
 	@echo '#define PS_PLAT_H'                          >> $(PLATFILE)
+	@echo '#define PS_WORDSIZE $(WORDSIZE)'            >> $(PLATFILE)
 	@echo '#include "plat/arch/$(ARCHNAME)/ps_arch.h"' >> $(PLATFILE)
 	@echo '#include "plat/os/$(OSNAME)/ps_os.h"'       >> $(PLATFILE)
 	@echo '#endif	/* PS_PLAT_H */'                   >> $(PLATFILE)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ config:
 	@rm -f $(PLATFILE)
 	@echo '#ifndef PS_PLAT_H'                          >  $(PLATFILE)
 	@echo '#define PS_PLAT_H'                          >> $(PLATFILE)
-	@echo '#define PS_WORDSIZE $(WORDSIZE)'            >> $(PLATFILE)
 	@echo '#include "plat/arch/$(ARCHNAME)/ps_arch.h"' >> $(PLATFILE)
 	@echo '#include "plat/os/$(OSNAME)/ps_os.h"'       >> $(PLATFILE)
 	@echo '#endif	/* PS_PLAT_H */'                   >> $(PLATFILE)

--- a/configure
+++ b/configure
@@ -7,4 +7,5 @@ if [ $# -ne 2 ]; then
 else
     echo "OSNAME   = $1" > Makefile.config
     echo "ARCHNAME = $2" >> Makefile.config
+    echo "WORDSIZE = $(getconf LONG_BIT)" >> Makefile.config
 fi

--- a/configure
+++ b/configure
@@ -3,9 +3,8 @@
 if [ $# -ne 2 ]; then
     echo "Usage: $0 osname archname"
     echo "\tosname is in {linux, cos}"
-    echo "\tarchname is in {x86}"
+    echo "\tarchname is in {x86, x86_64}"
 else
     echo "OSNAME   = $1" > Makefile.config
     echo "ARCHNAME = $2" >> Makefile.config
-    echo "WORDSIZE = $(getconf LONG_BIT)" >> Makefile.config
 fi

--- a/plat/arch/x86/ps_arch.h
+++ b/plat/arch/x86/ps_arch.h
@@ -39,9 +39,6 @@ typedef u16_t localityid_t;
 #define PS_PAGE_SIZE        4096
 #define PS_RNDUP(v, a)      (-(-(v) & -(a))) /* from blogs.oracle.com/jwadams/entry/macros_and_powers_of_two */
 
-#ifndef PS_WORDSIZE
-#define PS_WORDSIZE 32
-#endif
 #if PS_WORDSIZE == 32  /* x86-32 */
 #define PS_PLAT_SHIFTR32(v)
 #define PS_ATOMIC_POSTFIX "l"

--- a/plat/arch/x86/ps_arch_x86_common.h
+++ b/plat/arch/x86/ps_arch_x86_common.h
@@ -1,0 +1,138 @@
+/***
+ * Copyright 2015 by Gabriel Parmer.  All rights reserved.
+ * Redistribution of this file is permitted under the BSD 2 clause license.
+ *
+ * Authors: Gabriel Parmer, gparmer@gwu.edu, 2015
+ */
+
+/*
+ * TODO: most of this file should simply use the concurrency kit
+ * versions.
+ */
+
+#ifndef PS_ARCH_X86_COMMON_H
+#define PS_ARCH_X86_COMMON_H
+
+typedef unsigned short int u16_t;
+typedef unsigned int u32_t;
+typedef unsigned long long u64_t;
+typedef u64_t ps_tsc_t; 	/* our time-stamp counter representation */
+typedef u16_t coreid_t;
+typedef u16_t localityid_t;
+
+#ifndef likely
+#define likely(x)      __builtin_expect(!!(x), 1)
+#endif
+#ifndef unlikely
+#define unlikely(x)    __builtin_expect(!!(x), 0)
+#endif
+
+#define PS_CACHE_LINE       64
+#define PS_CACHE_PAD        (PS_CACHE_LINE*2)
+#define PS_CACHE_PAD_SZ(sz) (PS_CACHE_PAD - ((sz) % PS_CACHE_PAD))
+#define PS_WORD             sizeof(long)
+#define PS_PACKED           __attribute__((packed))
+#define PS_ALIGNED          __attribute__((aligned(PS_CACHE_LINE)))
+#define PS_WORDALIGNED      __attribute__((aligned(PS_WORD)))
+#define PS_PAGE_SIZE        4096
+#define PS_RNDUP(v, a)      (-(-(v) & -(a))) /* from blogs.oracle.com/jwadams/entry/macros_and_powers_of_two */
+
+#define PS_CAS_INSTRUCTION "cmpxchg"
+#define PS_FAA_INSTRUCTION "xadd"
+#define PS_CAS_STR PS_CAS_INSTRUCTION PS_ATOMIC_POSTFIX " %2, %0; setz %1"
+#define PS_FAA_STR PS_FAA_INSTRUCTION PS_ATOMIC_POSTFIX " %1, %0"
+
+#ifndef ps_cc_barrier
+#define ps_cc_barrier() __asm__ __volatile__ ("" : : : "memory")
+#endif
+
+/*
+ * Return values:
+ * 0 on failure due to contention (*target != old)
+ * 1 otherwise (*target == old -> *target = updated)
+ */
+static inline int
+ps_cas(unsigned long *target, unsigned long old, unsigned long updated)
+{
+        char z;
+        __asm__ __volatile__("lock " PS_CAS_STR
+                             : "+m" (*target), "=a" (z)
+                             : "q"  (updated), "a"  (old)
+                             : "memory", "cc");
+        return (int)z;
+}
+
+static inline long
+ps_faa(unsigned long *target, long inc)
+{
+        __asm__ __volatile__("lock " PS_FAA_STR
+                             : "+m" (*target), "+q" (inc)
+                             : : "memory", "cc");
+        return inc;
+}
+
+static inline void
+ps_mem_fence(void)
+{ __asm__ __volatile__("mfence" ::: "memory"); }
+
+#define ps_load(addr) (*(volatile __typeof__(*addr) *)(addr))
+
+/*
+ * Only atomic on a uni-processor, so not for cross-core coordination.
+ * Faster on a multiprocessor when used to synchronize between threads
+ * on a single core by avoiding locking.
+ */
+static inline int
+ps_upcas(unsigned long *target, unsigned long old, unsigned long updated)
+{
+        char z;
+        __asm__ __volatile__(PS_CAS_STR
+                             : "+m" (*target), "=a" (z)
+                             : "q"  (updated), "a"  (old)
+                             : "memory", "cc");
+        return (int)z;
+}
+
+static inline long
+ps_upfaa(unsigned long *target, long inc)
+{
+        __asm__ __volatile__(PS_FAA_STR
+                             : "+m" (*target), "+q" (inc)
+                             : : "memory", "cc");
+        return inc;
+}
+
+
+/*
+ * FIXME: this is truly an affront to humanity for now, but it is a
+ * simple lock for testing -- naive spin *without* backoff, gulp
+ *
+ * This is a great example where we should be using CK.
+ */
+struct ps_lock {
+	unsigned long o;
+};
+
+static inline void
+ps_lock_take(struct ps_lock *l)
+{ while (!ps_cas(&l->o, 0, 1)) ; }
+
+static inline void
+ps_lock_release(struct ps_lock *l)
+{ l->o = 0; }
+
+static inline void
+ps_lock_init(struct ps_lock *l)
+{ l->o = 0; }
+
+static inline ps_tsc_t
+ps_tsc(void)
+{
+	unsigned long a, d, c;
+
+	__asm__ __volatile__("rdtsc" : "=a" (a), "=d" (d), "=c" (c) : : );
+
+	return ((u64_t)d << 32) | (u64_t)a;
+}
+
+#endif /* PS_ARCH_X86_COMMON_H */

--- a/plat/arch/x86_64/ps_arch.h
+++ b/plat/arch/x86_64/ps_arch.h
@@ -15,8 +15,8 @@
 
 #include <ps_config.h>
 
-#define PS_PLAT_SHIFTR32(v)
-#define PS_ATOMIC_POSTFIX "l"
+#define PS_PLAT_SHIFTR32(v) (v |= v >> 32)
+#define PS_ATOMIC_POSTFIX "q"
 
 #include "ps_arch_x86_common.h"
 

--- a/plat/arch/x86_64/ps_arch_x86_common.h
+++ b/plat/arch/x86_64/ps_arch_x86_common.h
@@ -1,0 +1,1 @@
+../x86/ps_arch_x86_common.h

--- a/ps_config.h
+++ b/ps_config.h
@@ -40,14 +40,4 @@
 #define PS_NUMLOCALITIES 1
 #endif
 
-/*
- * Realistically, the architecture-specific code will often be generic
- * across word sizes (or use ifdefs to abstract that detail away).
- * Thus, I'm putting this in the config file, and it can be
- * over-ridden by `Makefile` `-D` flags.
- */
-#ifndef PS_WORDSIZE
-#define PS_WORDSIZE 32
-#endif
-
 #endif	/* PS_CONFIG_H */


### PR DESCRIPTION
### Summary of this Pull Request (PR)

Automatically configure  `PS_WORDSIZE`
Add x86_64 architecture

### Intent for your PR

Choose one (Mandatory):

- [ ] This PR is for a code-review and is intended to get feedback, but not to be pulled yet.
- [x] This PR is mature, and ready to be integrated into the repo.

### Reviewers (Mandatory):
@phanikishoreg @gparmer 

### Code Quality

As part of this pull request, I've considered the following:

[Style](https://github.com/gparmer/composite/raw/ppos/doc/style_guide/composite_coding_style.pdf):

- [x] Comments adhere to the Style Guide (SG)
- [x] Spacing adhere's to the SG
- [x] Naming adhere's to the SG
- [x] All other aspects of the SG are adhered to, or exceptions are justified in this pull request
- [ ] I have run the auto formatter on my code before submitting this PR (see doc/auto_formatter.md for instructions)

[Code Craftsmanship](http://www2.seas.gwu.edu/~gparmer/posts/2016-03-07-code-craftsmanship.html):

- [x] I've made an attempt to remove all redundant code
- [x] I've considered ways in which my changes might impact existing code, and cleaned it up
- [x] I've formatted the code in an effort to make it easier to read (proper error handling, function use, etc...)
- [x] I've commented appropriately where code is tricky
- [x] I agree that there is no "throw-away" code, and that code in this PR is of high quality

### Testing

I've tested the code using the following test programs (provide list here):

- list, ns, pgalloc, slab, smr
