### PR TITLE
Fix compilation on 64bit host

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -9,4 +9,9 @@ MAKE      = make
 COPT      = -O3
 CWARN     = -Wno-long-long
 CFLAGS    = -MD -MP -std=c11 -Wall -Wpedantic -Wextra $(CWARN) $(COPT) $(CINC) -Wno-unused-function
+
+ifeq ($(ARCHNAME), x86)
+CFLAGS+=-m32
+endif
+
 MAKEFLAGS = --no-print-directory --section-alignment 0x1000 -I$(PWD)

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -11,7 +11,7 @@ CWARN     = -Wno-long-long
 CFLAGS    = -MD -MP -std=c11 -Wall -Wpedantic -Wextra $(CWARN) $(COPT) $(CINC) -Wno-unused-function
 
 ifeq ($(ARCHNAME), x86)
-CFLAGS+=-m32
+CFLAGS   += -m32
 endif
 
 MAKEFLAGS = --no-print-directory --section-alignment 0x1000 -I$(PWD)


### PR DESCRIPTION
To fix compilation for x86 (32bit) on 64bit host. 
After merging this PR, I'll be able to update Composite side for 64bit host and more recent gcc errors fixed.
I'll update the submodule in my composite PR once this is approved.